### PR TITLE
fix for hyphenation splitting errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ Neural machine translation as a server, using SockEye
 + https://github.com/TartuNLP/truecaser
 
 ```
-pip3 install mxnet sentencepiece sockeye mosestokenizer estnltk
+pip3 install mxnet sentencepiece sockeye estnltk
+```
+
++ `mosestokenizer-py` fork:
+
+```
+pip install https://github.com/inoryy/mosestokenizer-py
 ```
 
 ## Usage in command-line:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip3 install mxnet sentencepiece sockeye estnltk
 + `mosestokenizer-py` fork:
 
 ```
-pip install https://github.com/inoryy/mosestokenizer-py
+pip install https://github.com/inoryy/mosestokenizer-py/archive/master.zip
 ```
 
 ## Usage in command-line:

--- a/nmtserver.py
+++ b/nmtserver.py
@@ -28,7 +28,7 @@ SOCKEYE_MODEL_FOLDER_ENETLV = ['en-et-lv-model']
 TRUECASE_MODEL_ENETLV = 'preprocessing-models/joint-truecase-enetlv.tc'
 SENTENCEPIECE_MODEL_ENETLV = 'preprocessing-models/sp.model'
 
-my_tokenizer = mosestokenizer.MosesTokenizer('en')
+my_tokenizer = mosestokenizer.MosesTokenizer('en', aggressive_hyphen_splitting=False)
 my_detokenizer = mosestokenizer.MosesDetokenizer('en')
 my_truecaser_enetlv = applytc.loadModel(TRUECASE_MODEL_ENETLV)
 my_segmenter_enetlv = spm.SentencePieceProcessor()


### PR DESCRIPTION
This fix should resolve the consistent hyphenation errors I've described in my report and will present at poster session today. It's not a full fix in the sense that resolving all the cases correctly would probably involve re-training the model on a dataset with more hyphenated samples, but I think it performs well as is.

Example:

* Source: Pesu õõtsub nööril edasi-tagasi.
* Current translation: The laundry's moving on the rope - back.
* After the fix: The laundry's going back and forth on the rope. 

---

Note that you need a fork of mosestokenizer, but aside from that no additional changes required.